### PR TITLE
Update scrolling-tabs.js

### DIFF
--- a/scrolling-tabs.js
+++ b/scrolling-tabs.js
@@ -834,7 +834,7 @@
         link: function(scope, element, attrs) {
           var scrollingTabsControl = new ScrollingTabsControl(element, $timeout),
               isWrappingAngularUIBTabset = element.find('uib-tabset').length > 0,
-              isWrappingAngularUITabset = isWrappingAngularUIBTabset || element.find('tabset, .scrtabs-tabs-movable-container .ng-isolate-scope > ul.nav').length > 0,
+              isWrappingAngularUITabset = isWrappingAngularUIBTabset || element.find('tabset, .scrtabs-tabs-movable-container ul.nav').length > 0,
               scrollToTabEdge = attrs.scrollToTabEdge && attrs.scrollToTabEdge.toLowerCase() === 'true',
               scrtc = {
                 hasTabContentOutsideMovableContainer: true


### PR DESCRIPTION
We always disable debug info on Production environment. Hence Production Version of angular app will never have scope references. 'ng-scope', 'ng-isolated-scope' could not present in angular app. can we remove '.ng-isolate-scope > ' from selector. Let me know your opinion on this.
